### PR TITLE
Add code coverage. Fix javadoc. Fix sneaky memory leak.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.example</groupId>
-    <artifactId>funky</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <artifactId>recordlens</artifactId>
+    <version>0.1-SNAPSHOT</version>
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <jmh.version>1.21</jmh.version>
+        <jmh.version>1.35</jmh.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
     </properties>
     <dependencies>
@@ -42,10 +42,57 @@
 
     <build>
         <plugins>
-            <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/sikina/recordtransformer/Accessor.java
+++ b/src/main/java/com/sikina/recordtransformer/Accessor.java
@@ -3,10 +3,14 @@ package com.sikina.recordtransformer;
 import java.io.Serializable;
 
 /**
- * We make our own functional interface rather than using something like Invokable
- * because we need the interface to be serializable in order to parse the method name.
+ * This is a serializable getter. Extending Serializable allows us to retain information
+ * like the method name, which lets this serve as both type checking and a reference
+ * to a field in a record.
  */
 @FunctionalInterface
 public interface Accessor<V> extends Serializable {
-    public V get();
+    /**
+     * @return the value in the record that corresponds to this field
+     */
+    V get();
 }

--- a/src/main/java/com/sikina/recordtransformer/ConstructorException.java
+++ b/src/main/java/com/sikina/recordtransformer/ConstructorException.java
@@ -1,0 +1,11 @@
+package com.sikina.recordtransformer;
+
+/**
+ * This is thrown when an error occurs while accessing or invoking the constructor
+ * of a record being wrapped by RecordLens
+ */
+public class ConstructorException extends RuntimeException {
+    ConstructorException(Throwable e) {
+        super("Error finding or invoking constructor", e);
+    }
+}

--- a/src/main/java/com/sikina/recordtransformer/GetterException.java
+++ b/src/main/java/com/sikina/recordtransformer/GetterException.java
@@ -1,0 +1,11 @@
+package com.sikina.recordtransformer;
+
+/**
+ * This is thrown when an error occurs while getting the value of a record field
+ * or while getting the name of a field via an Accessor function.
+ */
+public class GetterException extends RuntimeException {
+    GetterException(Throwable cause) {
+        super("error while trying to map to record attribute", cause);
+    }
+}

--- a/src/main/java/com/sikina/recordtransformer/PartialTransformation.java
+++ b/src/main/java/com/sikina/recordtransformer/PartialTransformation.java
@@ -1,16 +1,32 @@
 package com.sikina.recordtransformer;
 
+/**
+ * This is a transitory class used to make the Java compiler enforce
+ * type T when making the transformation {@code with(Accessor<T> getter, T val)}.
+ *
+ * This class should never be instantiated directly, nor should it be stored in a variable.
+ * Rather, you should create, use, and discard this class as part of a with + as chain:
+ * {@code with(Accessor<T> getter).as(T val)}
+ *
+ * @param <T> the type of the record wrapped by the corresponding RecordLens
+ * @param <V> the type of the field in T being updated
+ */
 public class PartialTransformation<T extends Record, V> {
     private final RecordLens<T> wrapper;
     private final Put putFunc;
     private final String key;
 
-    public PartialTransformation(RecordLens<T> wrapper, Put putFunc, String key) {
+    PartialTransformation(RecordLens<T> wrapper, Put putFunc, String key) {
         this.wrapper = wrapper;
         this.putFunc = putFunc;
         this.key = key;
     }
 
+    /**
+     * Complete the queuing of the transformation for the record.
+     * @param value the value to set the field to when transform is called.
+     * @return The original lens, for chaining.
+     */
     public RecordLens<T> as(V value) {
         putFunc.put(key, value);
         return wrapper;

--- a/src/main/java/com/sikina/recordtransformer/Put.java
+++ b/src/main/java/com/sikina/recordtransformer/Put.java
@@ -1,6 +1,10 @@
 package com.sikina.recordtransformer;
 
+/**
+ * Function interface used to pass Map::put to PartialTransformation
+ * Not for external use.
+ */
 @FunctionalInterface
-public interface Put {
-    public Object put(String key, Object value);
+interface Put {
+    Object put(String key, Object value);
 }

--- a/src/main/java/com/sikina/recordtransformer/exceptions/ConstructorException.java
+++ b/src/main/java/com/sikina/recordtransformer/exceptions/ConstructorException.java
@@ -1,7 +1,0 @@
-package com.sikina.recordtransformer.exceptions;
-
-public class ConstructorException extends RuntimeException {
-    public ConstructorException(Throwable e) {
-        super("Error finding or invoking constructor", e);
-    }
-}

--- a/src/main/java/com/sikina/recordtransformer/exceptions/GetterMappingException.java
+++ b/src/main/java/com/sikina/recordtransformer/exceptions/GetterMappingException.java
@@ -1,7 +1,0 @@
-package com.sikina.recordtransformer.exceptions;
-
-public class GetterMappingException extends RuntimeException {
-    public GetterMappingException(Throwable cause) {
-        super("error while trying to map to record attribute", cause);
-    }
-}

--- a/src/test/java/com/sikina/recordtransformer/RecordLensBenchmark.java
+++ b/src/test/java/com/sikina/recordtransformer/RecordLensBenchmark.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 3)
 @Measurement(iterations = 8)
 public class RecordLensBenchmark {
-    public static final int I = 10;
+    private static final int ITERATIONS = 10;
     public record LargeRecord(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j){}
 
     public static void main(String[] args) throws RunnerException {
@@ -30,7 +30,7 @@ public class RecordLensBenchmark {
     public void unsafeTransform() {
         LargeRecord start = new LargeRecord(1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         RecordLens<LargeRecord> lens = new RecordLens<>(start);
-        for (int i = 0; i < I; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             lens = lens
                 .withTypeUnsafe("a", i)
                 .withTypeUnsafe("b", i)
@@ -51,7 +51,7 @@ public class RecordLensBenchmark {
     public void safeTransform() {
         LargeRecord start = new LargeRecord(1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
         RecordLens<LargeRecord> lens = new RecordLens<>(start);
-        for (int i = 0; i < I; i++) {
+        for (int i = 0; i < ITERATIONS; i++) {
             lens = lens
                 .with(lens.rec()::a).as(i)
                 .with(lens.rec()::b).as(i)


### PR DESCRIPTION
- Jacoco code coverage, set to 90% req
- Javadoc
  - Fix html escaping issues
  - Add some code blocks
- Memory leak
  - Wasn't clearing update map in `transform`